### PR TITLE
Various fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 # Roast (Regal's Optimized AST)
 
 Roast is an optimized JSON format for [Rego](https://www.openpolicyagent.org/docs/latest/policy-language/) ASTs, as well
-as some common utilities for working with it.
+as common utilities for working with the both the Roast format and OPA's AST APIs.
 
 Roast is used by [Regal](https://docs.styra.com/regal), where the JSON representation of Rego's AST is used input for
 static analysis [performed by Rego itself](https://www.styra.com/blog/linting-rego-with-rego/) to determine whether
 policies conform to Regal's linter rules.
+
+> [!IMPORTANT]
+> This library changes frequently and provides no guarantees for what its API looks like. Depending on this library
+> directly is not recommended! If you find any code here useful, feel free to use it as your own in your projects, but
+> be aware that it may change at any time, and you may be better off copy-pasting whatever code you need.
 
 ## Goals
 
@@ -14,9 +19,10 @@ policies conform to Regal's linter rules.
 - As easy to read as the original AST JSON format
 
 While this module provides a way to encode an `ast.Module` to an optimized JSON format, it does not provide a decoder.
-In other words, there's no way to turn optimized AST JSON back into an `ast.Module` (or other AST types). While this
-would be possible to do, there's no real need for that given our current use-case for this format, which is to help work
-with the AST efficiently in Rego. Roast should not be considered a general purpose format for serializing the Rego AST.
+In other words, there's currently no way to turn optimized AST JSON back into an `ast.Module` (or other AST types).
+While this would be possible to do, there's no real need for that given our current use-case for this format, which is
+to help work with the AST efficiently in Rego. Roast should not be considered a general purpose format for serializing
+the Rego AST.
 
 ## Differences
 
@@ -215,3 +221,8 @@ uses `text` and `location` consistently.
 
 While the numbers may vary some, the Roast format is currently about 40-50% smaller in size than the original AST JSON
 format, and can be processed (in Rego, using `walk` and so on) about 1.25 times faster.
+
+## Community
+
+If you'd like to discuss OPA's AST, Roast or anything else related to OPA and Styra, please join us in the `#regal`
+channel in the Styra Community [Slack](https://communityinviter.com/apps/styracommunity/signup)!

--- a/internal/encoding/head.go
+++ b/internal/encoding/head.go
@@ -77,6 +77,13 @@ func (*headCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 			stream.WriteMore()
 		}
 
+		// Strip location from generated `true` values, as they don't have one
+		if head.Value.Location != nil && head.Location != nil {
+			if head.Value.Location.Row == head.Location.Row && head.Value.Location.Col == head.Location.Col {
+				head.Value.Location = nil
+			}
+		}
+
 		stream.WriteObjectField(strValue)
 		stream.WriteVal(head.Value)
 	}

--- a/internal/encoding/head_test.go
+++ b/internal/encoding/head_test.go
@@ -15,7 +15,7 @@ func TestRuleHeadEncoding(t *testing.T) {
 		Name: "omitted",
 		Reference: ast.Ref{
 			{
-				Value: ast.String("foo"),
+				Value: ast.Var("foo"),
 				Location: &ast.Location{
 					Row:  1,
 					Col:  1,
@@ -31,7 +31,6 @@ func TestRuleHeadEncoding(t *testing.T) {
 				},
 			},
 		},
-
 		Value: &ast.Term{
 			Value: ast.Boolean(true),
 			Location: &ast.Location{
@@ -58,7 +57,7 @@ func TestRuleHeadEncoding(t *testing.T) {
   "ref": [
     {
       "location": "1:1:1:4",
-      "type": "string",
+      "type": "var",
       "value": "foo"
     },
     {
@@ -77,5 +76,45 @@ func TestRuleHeadEncoding(t *testing.T) {
 
 	if string(bs) != expect {
 		t.Fatalf("expected %s but got %s", expect, string(bs))
+	}
+}
+
+func TestRuleHeadEncodingStripsLocationOfGeneratedValue(t *testing.T) {
+	t.Parallel()
+
+	head := ast.MustParseRule(`p[x] if { x := 1 }`).Head
+
+	bs, err := jsoniter.ConfigFastest.MarshalIndent(head, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := `{
+  "location": "1:1:1:5",
+  "ref": [
+    {
+      "location": "1:1:1:2",
+      "type": "var",
+      "value": "p"
+    },
+    {
+      "location": "1:3:1:4",
+      "type": "var",
+      "value": "x"
+    }
+  ],
+  "key": {
+    "location": "1:3:1:4",
+    "type": "var",
+    "value": "x"
+  },
+  "value": {
+    "type": "boolean",
+    "value": true
+  }
+}`
+
+	if string(bs) != expected {
+		t.Fatalf("expected %s but got %s", expected, string(bs))
 	}
 }

--- a/internal/encoding/module_test.go
+++ b/internal/encoding/module_test.go
@@ -245,7 +245,7 @@ func BenchmarkSerializeModule(b *testing.B) {
 
 	b.ResetTimer()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := json.Marshal(module)
 		if err != nil {
 			b.Fatalf("failed to marshal module: %v", err)

--- a/internal/encoding/term.go
+++ b/internal/encoding/term.go
@@ -30,45 +30,11 @@ func (*termCodec) Encode(ptr unsafe.Pointer, stream *jsoniter.Stream) {
 		}
 
 		stream.WriteObjectField(strType)
-		stream.WriteString(valueName(term.Value))
+		stream.WriteString(ast.ValueName(term.Value))
 		stream.WriteMore()
 		stream.WriteObjectField(strValue)
 		stream.WriteVal(term.Value)
 	}
 
 	stream.WriteObjectEnd()
-}
-
-// TODO: remove once this is in OPA and we can use that instead.
-func valueName(x ast.Value) string {
-	switch x.(type) {
-	case ast.String:
-		return "string"
-	case ast.Boolean:
-		return "boolean"
-	case ast.Number:
-		return "number"
-	case ast.Null:
-		return "null"
-	case ast.Var:
-		return "var"
-	case ast.Object:
-		return "object"
-	case ast.Set:
-		return "set"
-	case ast.Ref:
-		return "ref"
-	case ast.Call:
-		return "call"
-	case *ast.Array:
-		return "array"
-	case *ast.ArrayComprehension:
-		return "arraycomprehension"
-	case *ast.ObjectComprehension:
-		return "objectcomprehension"
-	case *ast.SetComprehension:
-		return "setcomprehension"
-	}
-
-	return ast.TypeName(x)
 }

--- a/internal/intern/intern.go
+++ b/internal/intern/intern.go
@@ -1,0 +1,159 @@
+package intern
+
+import (
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+var (
+	// These are strings commonly found in the AST of all Rego policies,
+	// like the name of built-in functions, keywords, etc.
+	strings = [...]string{
+		// Rego
+		"",
+		" ",
+		",",
+		"/",
+		"array",
+		"assign",
+		"data",
+		"description",
+		"equal",
+		"file",
+		"input",
+		"internal",
+		"member_2",
+		"number",
+		"object",
+		"policy",
+		"rego",
+		"set",
+		"type",
+		"var",
+		"string",
+		"text",
+		"v1",
+		"union",
+		"IE1FVEFEQVRB", // METADATA as enconded in the comment nodes
+		"v0",
+		"v1",
+		"v0v1",
+		"unknown",
+
+		// These are strings commonly found in linter policies, but
+		// not necessarily anywhere else.
+		"}",
+		"# METADATA",
+		"ast",
+		"boolean",
+		"bugs",
+		"call",
+		"category",
+		"col",
+		"config",
+		"error",
+		"idiomatic",
+		"level",
+		"location",
+		"module",
+		"violation",
+		"title",
+		"term",
+		"r",
+		"ref",
+		"regal",
+		"report",
+		"result",
+		"row",
+		"rule",
+		"rules",
+		"style",
+		"value",
+		"end",
+
+		// OPA / Roast keys
+		"alias",
+		"assign",
+		"authors",
+		"body",
+		"custom",
+		"default",
+		"description",
+		"else",
+		"entrypoint",
+		"head",
+		"imports",
+		"rules",
+		"package",
+		"annotations",
+		"comments",
+		"related_resources",
+		"scope",
+		"symbols",
+		"negated",
+		"key",
+		"term",
+		"domain",
+		"location",
+		"type",
+		"value",
+		"path",
+		"args",
+		"name",
+		"schema",
+		"schemas",
+		"terms",
+		"text",
+		"title",
+		"ref",
+		"with",
+		"target",
+
+		// Regal specific keys
+		"file",
+		"abs",
+		"environment",
+		"path_separator",
+		"lines",
+		"operations",
+		"regal",
+		"severity",
+		"col",
+		"row",
+		"end",
+		"package_path",
+		"rule",
+		"category",
+		"aggregate_source",
+		"aggregate_data",
+		"rego_version",
+		"negated_refs",
+		"ast",
+		"refs",
+		"config",
+		"lint",
+		"collect",
+	}
+
+	StringTerms  = stringTermsMap(strings[:])
+	StringValues = stringValuesMap(strings[:])
+)
+
+func stringTermsMap([]string) map[string]*ast.Term {
+	m := make(map[string]*ast.Term, len(strings))
+
+	for _, s := range strings {
+		m[s] = ast.NewTerm(StringValues[s])
+	}
+
+	return m
+}
+
+func stringValuesMap([]string) map[string]ast.Value {
+	m := make(map[string]ast.Value, len(strings))
+
+	for _, s := range strings {
+		m[s] = ast.String(s)
+	}
+
+	return m
+}

--- a/internal/transforms/value_test.go
+++ b/internal/transforms/value_test.go
@@ -37,7 +37,7 @@ func BenchmarkInterfaceToValue(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := AnyToValue(inputMap)
 		if err != nil {
 			b.Fatal(err)
@@ -54,7 +54,7 @@ func BenchmarkOPAInterfaceToValue(b *testing.B) {
 	b.ResetTimer()
 	b.ReportAllocs()
 
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		_, err := ast.InterfaceToValue(inputMap)
 		if err != nil {
 			b.Fatal(err)

--- a/pkg/intern/intern.go
+++ b/pkg/intern/intern.go
@@ -1,0 +1,26 @@
+package intern
+
+import (
+	"github.com/anderseknert/roast/internal/intern"
+
+	"github.com/open-policy-agent/opa/v1/ast"
+)
+
+// TODO: move to OPA.
+var EmptyArray = ast.NewArray()
+
+func StringTerm(s string) *ast.Term {
+	if t, ok := intern.StringTerms[s]; ok {
+		return t
+	}
+
+	return ast.StringTerm(s)
+}
+
+func StringValue(s string) ast.Value {
+	if v, ok := intern.StringValues[s]; ok {
+		return v
+	}
+
+	return ast.String(s)
+}

--- a/pkg/util/concurrent/map.go
+++ b/pkg/util/concurrent/map.go
@@ -1,0 +1,148 @@
+package concurrent
+
+import (
+	"maps"
+	"sync"
+)
+
+// Map provides a simple concurrent map implementation.
+type Map[K comparable, V any] struct {
+	m    map[K]V
+	murw sync.RWMutex
+}
+
+// ValueTransformer is a function that transforms a value in the map.
+type ValueTransformer[V any] func(V) V
+
+// MapOf creates a new concurrent map wrapping the given map.
+func MapOf[K comparable, V any](src map[K]V) *Map[K, V] {
+	return &Map[K, V]{
+		m:    src,
+		murw: sync.RWMutex{},
+	}
+}
+
+// Get returns the value associated with the given key, and a boolean indicating
+// whether the key was found.
+func (cm *Map[K, V]) Get(k K) (V, bool) {
+	cm.murw.RLock()
+
+	v, ok := cm.m[k]
+
+	cm.murw.RUnlock()
+
+	return v, ok
+}
+
+// GetUnchecked returns the value associated with the given key without checking
+// for its existence (nil if not found).
+func (cm *Map[K, V]) GetUnchecked(k K) V {
+	cm.murw.RLock()
+
+	v := cm.m[k]
+
+	cm.murw.RUnlock()
+
+	return v
+}
+
+// Set sets the value associated with the given key.
+func (cm *Map[K, V]) Set(k K, v V) {
+	cm.murw.Lock()
+
+	cm.m[k] = v
+
+	cm.murw.Unlock()
+}
+
+// Delete removes the value associated with the given key.
+func (cm *Map[K, V]) Delete(k K) {
+	cm.murw.Lock()
+
+	delete(cm.m, k)
+
+	cm.murw.Unlock()
+}
+
+// Keys returns a slice of all keys in the map.
+func (cm *Map[K, V]) Keys() []K {
+	cm.murw.RLock()
+
+	keys := make([]K, 0, len(cm.m))
+
+	for k := range cm.m {
+		keys = append(keys, k)
+	}
+
+	cm.murw.RUnlock()
+
+	return keys
+}
+
+// Values returns a slice of all values in the map.
+func (cm *Map[K, V]) Values() []V {
+	cm.murw.RLock()
+
+	vs := make([]V, len(cm.m))
+	i := 0
+
+	for _, v := range cm.m {
+		vs[i] = v
+		i++
+	}
+
+	cm.murw.RUnlock()
+
+	return vs
+}
+
+// Len returns the number of elements in the map.
+func (cm *Map[K, V]) Len() int {
+	if cm == nil {
+		return 0
+	}
+
+	cm.murw.RLock()
+
+	l := len(cm.m)
+
+	cm.murw.RUnlock()
+
+	return l
+}
+
+// Clone returns a shallow copy of the map.
+func (cm *Map[K, V]) Clone() map[K]V {
+	cm.murw.RLock()
+
+	m := maps.Clone(cm.m)
+
+	cm.murw.RUnlock()
+
+	return m
+}
+
+// Clear removes all elements from the map.
+func (cm *Map[K, V]) Clear() {
+	cm.murw.Lock()
+
+	clear(cm.m)
+
+	cm.murw.Unlock()
+}
+
+// UpdateValue updates the value associated with the given key using the provided
+// transformer function.
+func (cm *Map[K, V]) UpdateValue(key K, transformer ValueTransformer[V]) {
+	cm.murw.Lock()
+
+	var v V
+
+	if vo, ok := cm.m[key]; ok {
+		v = vo
+	}
+
+	cm.m[key] = transformer(v)
+
+	cm.murw.Unlock()
+}

--- a/pkg/util/set.go
+++ b/pkg/util/set.go
@@ -1,0 +1,68 @@
+package util
+
+// Set is a generic set implementation.
+type Set[T comparable] struct {
+	elements map[T]struct{}
+}
+
+// NewSet creates a new set from the supplied items.
+func NewSet[T comparable](items ...T) *Set[T] {
+	s := &Set[T]{elements: make(map[T]struct{})}
+
+	s.Add(items...)
+
+	return s
+}
+
+// Add adds one or more items to the set.
+func (s *Set[T]) Add(items ...T) {
+	for _, item := range items {
+		s.elements[item] = struct{}{}
+	}
+}
+
+// Remove removes one or more items from the set.
+func (s *Set[T]) Remove(items ...T) {
+	for _, item := range items {
+		delete(s.elements, item)
+	}
+}
+
+// Contains checks if all given items are in the set.
+func (s *Set[T]) Contains(items ...T) bool {
+	for _, item := range items {
+		if _, exists := s.elements[item]; !exists {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Size returns the number of elements in the set.
+func (s *Set[T]) Size() int {
+	return len(s.elements)
+}
+
+// Items returns all elements as a slice.
+func (s *Set[T]) Items() []T {
+	items := make([]T, 0, len(s.elements))
+	for item := range s.elements {
+		items = append(items, item)
+	}
+
+	return items
+}
+
+// Diff returns a new set containing items from the current set that are not in the given set B.
+func (s *Set[T]) Diff(b *Set[T]) *Set[T] {
+	diffSet := NewSet[T]()
+
+	for item := range s.elements {
+		if !b.Contains(item) {
+			diffSet.Add(item)
+		}
+	}
+
+	return diffSet
+}

--- a/pkg/util/set_test.go
+++ b/pkg/util/set_test.go
@@ -1,0 +1,169 @@
+package util
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestNewSet(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet(1, 2, 3)
+
+	if got, expected := s.Size(), 3; got != expected {
+		t.Fatalf("unexpected size, got: %v, want: %v", got, expected)
+	}
+
+	if got, expected := s.Contains(1, 2, 3), true; got != expected {
+		t.Fatalf("unexpected Contains result, got: %v, want: %v", got, expected)
+	}
+
+	if got, expected := s.Contains(4), false; got != expected {
+		t.Fatalf("unexpected Contains result for missing element, got: %v, want: %v", got, expected)
+	}
+}
+
+func TestAdd(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet[int]()
+	s.Add(10)
+
+	if got, expected := s.Contains(10), true; got != expected {
+		t.Fatalf("unexpected Contains result after Add, got: %v, want: %v", got, expected)
+	}
+
+	s.Add(20, 30, 40)
+
+	if got, expected := s.Contains(20, 30, 40), true; got != expected {
+		t.Fatalf("unexpected Contains result after adding multiple elements, got: %v, want: %v", got, expected)
+	}
+
+	initialSize := s.Size()
+	s.Add(10, 20)
+
+	if got, expected := s.Size(), initialSize; got != expected {
+		t.Fatalf("size changed after adding duplicate elements, got: %v, want: %v", got, expected)
+	}
+}
+
+func TestRemove(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet(1, 2, 3, 4, 5)
+	s.Remove(2)
+
+	if got, expected := s.Contains(2), false; got != expected {
+		t.Fatalf("unexpected Contains result after Remove, got: %v, want: %v", got, expected)
+	}
+
+	s.Remove(1, 3, 5)
+	s.Remove(100, 200) // Removing random elements should be ok too
+
+	if got, expected := s.Contains(1, 3, 5), false; got != expected {
+		t.Fatalf("unexpected Contains result after removing multiple elements, got: %v, want: %v", got, expected)
+	}
+}
+
+func TestContains(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet("apple", "banana", "cherry")
+
+	if got, expected := s.Contains("banana"), true; got != expected {
+		t.Fatalf("unexpected Contains result for existing element, got: %v, want: %v", got, expected)
+	}
+
+	if got, expected := s.Contains("apple", "banana"), true; got != expected {
+		t.Fatalf("unexpected Contains result for multiple existing elements, got: %v, want: %v", got, expected)
+	}
+
+	if got, expected := s.Contains("grape"), false; got != expected {
+		t.Fatalf("unexpected Contains result for missing element, got: %v, want: %v", got, expected)
+	}
+
+	if got, expected := s.Contains("banana", "grape"), false; got != expected {
+		t.Fatalf("unexpected Contains result when at least one element is missing, got: %v, want: %v", got, expected)
+	}
+}
+
+func TestSize(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet(1, 2, 3)
+
+	if got, expected := s.Size(), 3; got != expected {
+		t.Fatalf("unexpected size, got: %v, want: %v", got, expected)
+	}
+
+	s.Add(4, 5)
+
+	if got, expected := s.Size(), 5; got != expected {
+		t.Fatalf("unexpected size after Add, got: %v, want: %v", got, expected)
+	}
+
+	s.Remove(2, 3)
+
+	if got, expected := s.Size(), 3; got != expected {
+		t.Fatalf("unexpected size after Remove, got: %v, want: %v", got, expected)
+	}
+}
+
+func TestItems(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet(1, 2, 3, 4)
+	items := s.Items()
+	expected := []int{1, 2, 3, 4}
+
+	slices.Sort(items)
+	slices.Sort(expected)
+
+	if got := slices.Equal(expected, items); !got {
+		t.Fatalf("unexpected Items result, got: %v, want: %v", items, expected)
+	}
+
+	s.Remove(2, 3)
+
+	expected = []int{1, 4}
+	items = s.Items()
+
+	slices.Sort(items)
+	slices.Sort(expected)
+
+	if got := slices.Equal(expected, items); !got {
+		t.Fatalf("unexpected Items result after Remove, got: %v, want: %v", items, expected)
+	}
+}
+
+func TestEmptySet(t *testing.T) {
+	t.Parallel()
+
+	s := NewSet[int]()
+
+	if got, expected := s.Size(), 0; got != expected {
+		t.Fatalf("unexpected size for empty set, got: %v, want: %v", got, expected)
+	}
+
+	if got := len(s.Items()); got != 0 {
+		t.Fatalf("unexpected Items result for empty set, got: %v, want: %v", got, 0)
+	}
+}
+
+func TestDiff(t *testing.T) {
+	t.Parallel()
+
+	a := NewSet(1, 2, 3, 4, 5)
+	b := NewSet(3, 4, 5, 6, 7)
+
+	diffSet := a.Diff(b)
+	expected := []int{1, 2}
+
+	items := diffSet.Items()
+	slices.Sort(items)
+	slices.Sort(expected)
+
+	if got := slices.Equal(expected, items); !got {
+		t.Fatalf("unexpected Diff result, got: %v, want: %v", items, expected)
+	}
+}


### PR DESCRIPTION
- Don't print location for object rule with implied true value
- Copy concurrent map code from Regal to here
- Copy Set implementation from Regal to here
- Use ast.ValueName from OPA now that it's been upstreamed
- Add a few more common string terms for interning
- Some README updates preparing to move repo to Styra org
- Add ToAST function to build entire Regal AST in Roast
- Better organization of interned values and terms