### PR TITLE
testing: Use the embed package for testdata

### DIFF
--- a/internal/encoding/annotations_test.go
+++ b/internal/encoding/annotations_test.go
@@ -1,8 +1,8 @@
 package encoding
 
 import (
+	"embed"
 	"net/url"
-	"os"
 	"reflect"
 	"testing"
 
@@ -10,6 +10,9 @@ import (
 
 	"github.com/open-policy-agent/opa/v1/ast"
 )
+
+//go:embed testdata
+var testData embed.FS
 
 func TestAnnotationsEncoding(t *testing.T) {
 	t.Parallel()
@@ -92,7 +95,7 @@ func TestAnnotationsEncoding(t *testing.T) {
 		t.Fatalf("failed to unmarshal JSON: %v", err)
 	}
 
-	expected := MustReadFile(t, "testdata/annotations_all.json")
+	expected := mustReadTestFile(t, "testdata/annotations_all.json")
 
 	var expectedMap map[string]any
 
@@ -125,24 +128,11 @@ func mapToAnyPointer(m map[string]any) *any {
 	return &p
 }
 
-func MustReadFile(t *testing.T, path string) []byte {
-	t.Helper()
-
-	bs, err := os.ReadFile(path)
+func mustReadTestFile(tb testing.TB, path string) []byte {
+	tb.Helper()
+	b, err := testData.ReadFile(path)
 	if err != nil {
-		t.Fatalf("failed to read file %s: %v", path, err)
+		tb.Fatalf("Read file %s: %v", path, err)
 	}
-
-	return bs
-}
-
-func MustReadFileBench(b *testing.B, path string) []byte {
-	b.Helper()
-
-	bs, err := os.ReadFile(path)
-	if err != nil {
-		b.Fatalf("failed to read file %s: %v", path, err)
-	}
-
-	return bs
+	return b
 }

--- a/internal/encoding/module_test.go
+++ b/internal/encoding/module_test.go
@@ -212,7 +212,7 @@ func TestRuleAndDocumentScopedAnnotationsOnPackageAreDropped(t *testing.T) {
 func TestSerializedModuleSize(t *testing.T) {
 	t.Parallel()
 
-	policy := MustReadFile(t, "testdata/policy.rego")
+	policy := mustReadTestFile(t, "testdata/policy.rego")
 	module := ast.MustParseModuleWithOpts(string(policy), ast.ParserOptions{
 		ProcessAnnotation: true,
 	})
@@ -236,7 +236,7 @@ func TestSerializedModuleSize(t *testing.T) {
 // BenchmarkSerializeModule-10    	    2488	    479095 ns/op	  217090 B/op	    9805 allocs/op
 
 func BenchmarkSerializeModule(b *testing.B) {
-	policy := MustReadFileBench(b, "testdata/policy.rego")
+	policy := mustReadTestFile(b, "testdata/policy.rego")
 	module := ast.MustParseModuleWithOpts(string(policy), ast.ParserOptions{
 		ProcessAnnotation: true,
 	})

--- a/internal/transforms/value_test.go
+++ b/internal/transforms/value_test.go
@@ -1,13 +1,16 @@
 package transforms
 
 import (
-	"os"
+	"embed"
 	"testing"
 
 	"github.com/open-policy-agent/opa/v1/ast"
 
 	"github.com/styrainc/roast/pkg/encoding"
 )
+
+//go:embed testdata
+var testData embed.FS
 
 func TestRoastAndOPAInterfaceToValueSameOutput(t *testing.T) {
 	t.Parallel()
@@ -65,10 +68,7 @@ func BenchmarkOPAInterfaceToValue(b *testing.B) {
 func inputMap(t *testing.T) map[string]any {
 	t.Helper()
 
-	bs, err := os.ReadFile("testdata/ast.rego")
-	if err != nil {
-		t.Fatal(err)
-	}
+	bs := mustReadTestFile(t, "testdata/ast.rego")
 
 	content := string(bs)
 
@@ -89,10 +89,7 @@ func inputMap(t *testing.T) map[string]any {
 func inputMapB(b *testing.B) map[string]any {
 	b.Helper()
 
-	bs, err := os.ReadFile("testdata/ast.rego")
-	if err != nil {
-		b.Fatal(err)
-	}
+	bs := mustReadTestFile(b, "testdata/ast.rego")
 
 	content := string(bs)
 
@@ -108,4 +105,13 @@ func inputMapB(b *testing.B) map[string]any {
 	}
 
 	return inputMap
+}
+
+func mustReadTestFile(tb testing.TB, path string) []byte {
+	tb.Helper()
+	b, err := testData.ReadFile(path)
+	if err != nil {
+		tb.Fatalf("Read file %s: %v", path, err)
+	}
+	return b
 }


### PR DESCRIPTION
This moves a runtime check to a build check.